### PR TITLE
Use the correct function to normalize an absolute path

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,7 @@
-import { Menu, MenuItem, normalizePath, Notice, Platform, Plugin, PluginSettingTab, Setting, TFile } from 'obsidian';
+import { Menu, MenuItem, Notice, Platform, Plugin, PluginSettingTab, Setting, TFile } from 'obsidian';
 import open from "open";
 import { shell } from "electron";
+import { normalize } from "path";
 
 interface AppPair {
 	name: string;
@@ -113,7 +114,7 @@ export default class OpenWithPlugin extends Plugin {
 
 	getAbsolutePathOfFile(file: TFile): string {
 		//@ts-ignore
-		const path = normalizePath(`${this.app.vault.adapter.basePath}/${file.path}`)
+		const path = normalize(`${this.app.vault.adapter.basePath}/${file.path}`);
 		if (Platform.isDesktopApp && navigator.platform === "Win32") {
 			return path.replace(/\//g, "\\");
 		}


### PR DESCRIPTION
This plugin does not work correctly on Linux because an 'absolute' path that you get from the `getAbsolutePathOfFile` function does not contain leading `/` (so the path is not absolute). For example, if I want to open a note in NeoVim, the resulting command will look something like this: `nvim home/user/Documents/Obsidian/Note.md`. But should instead be: `nvim /home/user/Documents/Obsidian/Note.md`.

I used this forum post to resolve this issue: [normalizePath() removes a leading /](https://forum.obsidian.md/t/normalizepath-removes-a-leading/24713).